### PR TITLE
Sub-Specs now valid OpenApi-Specs

### DIFF
--- a/members.yaml
+++ b/members.yaml
@@ -1,195 +1,200 @@
-/members:
-  get:
-    summary: List of all members
-    operationId: listMembers
-    tags:
-      - Members
-    parameters:
-      - name: limit
-        in: query
-        description: How many items to return at one time
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 20
-      - name: start
-        in: query
-        description: How many items to skip
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: orderBy
-        in: query
-        description: The field by which the result is to be sorted
-        required: false
-        schema:
-          type: string
-          default: lastName
-      - name: direction
-        in: query
-        description: the sorting direction
-        required: false
-        schema:
-          type: string
-          enum: ["asc", "desc"]
-          default: "asc"
-    responses:
-      '200':
-        description: A paged array of members
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                  $ref: '#/components/schemas/ListMember'
-      '400':
-        description: This error is thrown when the parameters are faulty
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-  post:
-    summary: Create a member
-    operationId: createMembers
-    requestBody:
-      description: Member to add
-      required: true
-      content:
-        application/json:
+openapi: 3.0.0
+info:
+  title: "Sub-API-Spec"
+  version: 0.0.0
+paths:
+  /members:
+    get:
+      summary: List of all members
+      operationId: listMembers
+      tags:
+        - Members
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time
+          required: false
           schema:
-            $ref: '#/components/schemas/NewMember'
-    tags:
-      - Members
-    responses:
-      '200':
-        description: Responds with the member and all his fields
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Member'
-      '400':
-        description: Response when request is wrong, i.e. if required fields are empty
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-'/members/{id}':
-  get:
-    summary: Info for a specific member
-    operationId: showMemberById
-    tags:
-      - Members
-    parameters:
-      - name: id
-        in: path
-        required: true
-        description: The id of the member to retrieve
-        schema:
-          type: integer
-          format: int32
-    responses:
-      '200':
-        description: Expected response to a valid request
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Member'
-      '404':
-        description: Response when no member found
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-  put:
-    summary: Update a specific member
-    operationId: updateMemberById
-    tags:
-      - Members
-    parameters:
-      - name: id
-        in: path
-        required: true
-        description: The id of the member to update
-        schema:
-          type: integer
-          format: int32
-    requestBody:
-      description: Member to update
-      required: true
-      content:
-        application/json:
+            type: integer
+            format: int32
+            default: 20
+        - name: start
+          in: query
+          description: How many items to skip
+          required: false
           schema:
-            $ref: '#/components/schemas/NewMember'
-    responses:
-      '204':
-        description: Expected response to a valid request
-      '400':
-        description: Response when request is wrong, i.e. if required fields are empty
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-      '404':
-        description: Response when no member found
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-  delete:
-    summary: Delete specific member
-    operationId: deleteMemberById
-    tags:
-      - Members
-    parameters:
-      - name: id
-        in: path
+            type: integer
+            format: int32
+            default: 0
+        - name: orderBy
+          in: query
+          description: The field by which the result is to be sorted
+          required: false
+          schema:
+            type: string
+            default: lastName
+        - name: direction
+          in: query
+          description: the sorting direction
+          required: false
+          schema:
+            type: string
+            enum: ["asc", "desc"]
+            default: "asc"
+      responses:
+        '200':
+          description: A paged array of members
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                    $ref: '#/components/schemas/ListMember'
+        '400':
+          description: This error is thrown when the parameters are faulty
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+    post:
+      summary: Create a member
+      operationId: createMembers
+      requestBody:
+        description: Member to add
         required: true
-        description: The id of the member to delete
-        schema:
-          type: integer
-          format: int32
-    responses:
-      '204':
-        description: Expected response to a valid request
-      '404':
-        description: Response when no member found
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
+              $ref: '#/components/schemas/NewMember'
+      tags:
+        - Members
+      responses:
+        '200':
+          description: Responds with the member and all his fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Member'
+        '400':
+          description: Response when request is wrong, i.e. if required fields are empty
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+  '/members/{id}':
+    get:
+      summary: Info for a specific member
+      operationId: showMemberById
+      tags:
+        - Members
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the member to retrieve
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Member'
+        '404':
+          description: Response when no member found
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+    put:
+      summary: Update a specific member
+      operationId: updateMemberById
+      tags:
+        - Members
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the member to update
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        description: Member to update
+        required: true
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: '#/components/schemas/NewMember'
+      responses:
+        '204':
+          description: Expected response to a valid request
+        '400':
+          description: Response when request is wrong, i.e. if required fields are empty
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        '404':
+          description: Response when no member found
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+    delete:
+      summary: Delete specific member
+      operationId: deleteMemberById
+      tags:
+        - Members
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the member to delete
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '204':
+          description: Expected response to a valid request
+        '404':
+          description: Response when no member found
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
 components:
   schemas:
     NewMember:
@@ -247,7 +252,7 @@ components:
             services:
               type: array
               items:
-                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Service'
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Service'
         - $ref: '#/components/schemas/NewMember'
     ListMember:
       required:

--- a/members.yaml
+++ b/members.yaml
@@ -55,13 +55,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
     post:
       summary: Create a member
       operationId: createMembers
@@ -86,17 +86,17 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
   '/members/{id}':
     get:
       summary: Info for a specific member
-      operationId: showMemberById
+      operationId: shoMemberById
       tags:
         - Members
       parameters:
@@ -119,13 +119,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
     put:
       summary: Update a specific member
       operationId: updateMemberById
@@ -154,19 +154,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         '404':
           description: Response when no member found
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
     delete:
       summary: Delete specific member
       operationId: deleteMemberById
@@ -188,13 +188,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
 components:
   schemas:
     NewMember:
@@ -252,7 +252,7 @@ components:
             services:
               type: array
               items:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Service'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Service'
         - $ref: '#/components/schemas/NewMember'
     ListMember:
       required:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,13 +8,13 @@ servers:
   - url: 'http://will-code-for-food-and-water.feste-ip.net/backend_api/'
 paths:
   /members:
-    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/~1members'
+    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/paths/~1members'
   '/members/{id}':
-    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/~1members~1%7Bid%7D'
+    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/paths/~1members~1%7Bid%7D'
   /planes:
-    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/~1planes'
-  '/planes/{id}': 
-    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/~1planes~1%7Bid%7D'
+    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/paths/~1planes'
+  '/planes/{id}':
+    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/paths/~1planes~1%7Bid%7D'
   /fees:
     get:
       summary: List of fees

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,20 +1,20 @@
 openapi: 3.0.0
 info:
   version: 0.3.4
-  title: will-code-for-food-and-water - Spec
+  title: WWI16AMA - Spec
   license:
     name: APL 2
 servers:
-  - url: 'http://will-code-for-food-and-water.feste-ip.net/backend_api/'
+  - url: 'http://wwi16ama.feste-ip.net/backend_api/'
 paths:
   /members:
-    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/paths/~1members'
+    $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/paths/~1members'
   '/members/{id}':
-    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/paths/~1members~1%7Bid%7D'
+    $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/paths/~1members~1%7Bid%7D'
   /planes:
-    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/paths/~1planes'
+    $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/planes.yaml#/paths/~1planes'
   '/planes/{id}':
-    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/paths/~1planes~1%7Bid%7D'
+    $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/planes.yaml#/paths/~1planes~1%7Bid%7D'
   /fees:
     get:
       summary: List of fees
@@ -185,13 +185,13 @@ paths:
 components:
   schemas:
     Member:
-      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/components/schemas/Member'
+      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/Member'
     NewMember:
-      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/components/schemas/NewMember'
+      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/NewMember'
     ListMember:
-      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/components/schemas/ListMember'
+      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/ListMember'
     Address:
-      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/components/schemas/Address'
+      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/Address'
     Service:
       description: "Für Abrechnung später schlage ich vor, diese Klasse einzuführen. Service erweitert / flankiert __Offices__" 
       properties:
@@ -216,9 +216,9 @@ components:
         message:
           type: string
     NewPlane:
-      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/components/schemas/NewPlane'      
+      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/planes.yaml#/components/schemas/NewPlane'      
     Plane:
-      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/components/schemas/Plane'
+      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/planes.yaml#/components/schemas/Plane'
     Fee:
       required:
         - category

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,20 +1,20 @@
 openapi: 3.0.0
 info:
   version: 0.3.4
-  title: WWI16AMA - Spec
+  title: will-code-for-food-and-water - Spec
   license:
     name: APL 2
 servers:
-  - url: 'http://wwi16ama.feste-ip.net/backend_api/'
+  - url: 'http://will-code-for-food-and-water.feste-ip.net/backend_api/'
 paths:
   /members:
-    $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/~1members'
+    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/~1members'
   '/members/{id}':
-    $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/~1members~1%7Bid%7D'
+    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/~1members~1%7Bid%7D'
   /planes:
-    $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/planes.yaml#/~1planes'
+    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/~1planes'
   '/planes/{id}': 
-    $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/planes.yaml#/~1planes~1%7Bid%7D'
+    $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/~1planes~1%7Bid%7D'
   /fees:
     get:
       summary: List of fees
@@ -185,13 +185,13 @@ paths:
 components:
   schemas:
     Member:
-      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/Member'
+      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/components/schemas/Member'
     NewMember:
-      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/NewMember'
+      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/components/schemas/NewMember'
     ListMember:
-      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/ListMember'
+      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/components/schemas/ListMember'
     Address:
-      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/Address'
+      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/members.yaml#/components/schemas/Address'
     Service:
       description: "Für Abrechnung später schlage ich vor, diese Klasse einzuführen. Service erweitert / flankiert __Offices__" 
       properties:
@@ -216,9 +216,9 @@ components:
         message:
           type: string
     NewPlane:
-      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/planes.yaml#/components/schemas/NewPlane'      
+      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/components/schemas/NewPlane'      
     Plane:
-      $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/planes.yaml#/components/schemas/Plane'
+      $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/planes.yaml#/components/schemas/Plane'
     Fee:
       required:
         - category

--- a/planes.yaml
+++ b/planes.yaml
@@ -55,13 +55,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
     post:
       summary: Create a plane
       operationId: createPlanes
@@ -86,13 +86,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
   '/planes/{id}':
     get:
       summary: Info for a specific plane
@@ -121,13 +121,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
     put:
       summary: Update a specific plane
       operationId: updatePlaneById
@@ -156,19 +156,19 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         '404':
           description: Response when no plane found
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
     delete:
       summary: Delete specific plane
       operationId: deletePlaneById
@@ -190,13 +190,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
 components:
   schemas:
     NewPlane:

--- a/planes.yaml
+++ b/planes.yaml
@@ -50,13 +50,13 @@
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
       default:
         description: unexpected error
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
   post:
     summary: Create a plane
     operationId: createPlanes
@@ -81,13 +81,13 @@
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
       default:
         description: unexpected error
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
 '/planes/{id}':
   get:
     summary: Info for a specific plane
@@ -116,13 +116,13 @@
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
       default:
         description: unexpected error
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
   put:
     summary: Update a specific plane
     operationId: updatePlaneById
@@ -151,19 +151,19 @@
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
       '404':
         description: Response when no plane found
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
       default:
         description: unexpected error
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
   delete:
     summary: Delete specific plane
     operationId: deletePlaneById
@@ -185,13 +185,13 @@
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
       default:
         description: unexpected error
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
 components:
   schemas:
     NewPlane:

--- a/planes.yaml
+++ b/planes.yaml
@@ -1,197 +1,202 @@
-/planes:
-  get:
-    summary: List of all planes
-    operationId: listPlanes
-    tags:
-      - Planes
-    parameters: 
-      - name: limit
-        in: query
-        description: How many planes to return at one time
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 20
-      - name: start
-        in: query
-        description: How many planes to skip
-        required: false
-        schema:
-          type: integer
-          format: int32
-          default: 0
-      - name: orderBy
-        in: query
-        description: The field by which the result is to be sorted
-        required: false
-        schema:
-          type: string
-          default: name
-      - name: direction
-        in: query
-        description: the sorting direction
-        required: false
-        schema:
-          type: string
-          enum: ["asc", "desc"]
-          default: "asc"
-    responses:
-      '200':
-        description: A paged array of planes
-        content:
-          application/json:
-            schema:
-              type: array
-              items: 
-                $ref: '#/components/schemas/Plane'
-      '400':
-        description: This error is thrown when the parameters are faulty
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-  post:
-    summary: Create a plane
-    operationId: createPlanes
-    requestBody:
-      description: Plane to add
-      required: true
-      content:
-        application/json:
+openapi: 3.0.0
+info:
+  title: "Sub-Spec"
+  version: 0.0.0
+paths:
+  /planes:
+    get:
+      summary: List of all planes
+      operationId: listPlanes
+      tags:
+        - Planes
+      parameters: 
+        - name: limit
+          in: query
+          description: How many planes to return at one time
+          required: false
           schema:
-            $ref: '#/components/schemas/NewPlane'
-    tags:
-      - Planes
-    responses:
-      '200':
-        description: Responds with the plane and all his fields
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Plane'
-      '400':
-        description: Response when request is wrong, i.e. if required fields are empty
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-'/planes/{id}':
-  get:
-    summary: Info for a specific plane
-    operationId: showPlaneById
-    tags:
-      - Planes
-    parameters:
-      - name: id
-        in: path
-        required: true
-        description: The id of the plane to retrieve
-        schema:
-          type: integer
-          format: int32
-    responses:
-      '200':
-        description: Expected response to a valid request
-        content:
-          application/json:
-            schema:
-              type: array
-              items:
-                $ref: '#/components/schemas/Plane'
-      '404':
-        description: Response when no plane found
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-  put:
-    summary: Update a specific plane
-    operationId: updatePlaneById
-    tags:
-      - Planes
-    parameters:
-      - name: id
-        in: path
-        required: true
-        description: The id of the plane to update
-        schema:
-          type: integer
-          format: int32
-    requestBody:
-      description: plane to update
-      required: true
-      content:
-        application/json:
+            type: integer
+            format: int32
+            default: 20
+        - name: start
+          in: query
+          description: How many planes to skip
+          required: false
           schema:
-            $ref: '#/components/schemas/NewPlane'
-    responses:
-      '204':
-        description: Expected response to a valid request
-      '400':
-        description: Response when request is wrong, i.e. if required fields are empty
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-      '404':
-        description: Response when no plane found
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
-        content:
-          application/json:
-            schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-  delete:
-    summary: Delete specific plane
-    operationId: deletePlaneById
-    tags:
-      - Planes
-    parameters:
-      - name: id
-        in: path
+            type: integer
+            format: int32
+            default: 0
+        - name: orderBy
+          in: query
+          description: The field by which the result is to be sorted
+          required: false
+          schema:
+            type: string
+            default: name
+        - name: direction
+          in: query
+          description: the sorting direction
+          required: false
+          schema:
+            type: string
+            enum: ["asc", "desc"]
+            default: "asc"
+      responses:
+        '200':
+          description: A paged array of planes
+          content:
+            application/json:
+              schema:
+                type: array
+                items: 
+                  $ref: '#/components/schemas/Plane'
+        '400':
+          description: This error is thrown when the parameters are faulty
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+    post:
+      summary: Create a plane
+      operationId: createPlanes
+      requestBody:
+        description: Plane to add
         required: true
-        description: The id of the plane to delete
-        schema:
-          type: integer
-          format: int32
-    responses:
-      '204':
-        description: Expected response to a valid request
-      '404':
-        description: Response when no plane found
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
-      default:
-        description: unexpected error
+              $ref: '#/components/schemas/NewPlane'
+      tags:
+        - Planes
+      responses:
+        '200':
+          description: Responds with the plane and all his fields
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plane'
+        '400':
+          description: Response when request is wrong, i.e. if required fields are empty
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+  '/planes/{id}':
+    get:
+      summary: Info for a specific plane
+      operationId: showPlaneById
+      tags:
+        - Planes
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the plane to retrieve
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Plane'
+        '404':
+          description: Response when no plane found
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+    put:
+      summary: Update a specific plane
+      operationId: updatePlaneById
+      tags:
+        - Planes
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the plane to update
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        description: plane to update
+        required: true
         content:
           application/json:
             schema:
-              $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+              $ref: '#/components/schemas/NewPlane'
+      responses:
+        '204':
+          description: Expected response to a valid request
+        '400':
+          description: Response when request is wrong, i.e. if required fields are empty
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        '404':
+          description: Response when no plane found
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+    delete:
+      summary: Delete specific plane
+      operationId: deletePlaneById
+      tags:
+        - Planes
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the plane to delete
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '204':
+          description: Expected response to a valid request
+        '404':
+          description: Response when no plane found
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/will-code-for-food-and-water/api_spec/master/openapi.yaml#/components/schemas/Error'
 components:
   schemas:
     NewPlane:


### PR DESCRIPTION
dadurch kann man z.b. die `members.yaml` deutlich besser editieren, da diese inzw. im swagger-editor keine Fehler mehr werfen.

*Inhaltlich ändert sich nichts*