### PR TITLE
Add loginCheck route

### DIFF
--- a/members.yaml
+++ b/members.yaml
@@ -71,7 +71,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewMember'
+              $ref: '#/components/schemas/PostMember'
       tags:
         - Members
       responses:
@@ -145,7 +145,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/NewMember'
+              $ref: '#/components/schemas/PutMember'
       responses:
         '204':
           description: Expected response to a valid request
@@ -195,9 +195,99 @@ paths:
             application/json:
               schema:
                 $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+  '/members/{id}/changePassword':
+    put:
+      summary: Change the password of a specific member
+      operationId: updatePasswordAsUser
+      tags:
+        - Members
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the member who wants to update his password
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        description: Old and new Password
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                password:
+                  $ref: '#/components/schemas/Password'
+                newPassword:
+                  $ref: '#/components/schemas/Password'
+      responses:
+        '204':
+          description: Expected response to a valid request
+        '400':
+          description: When the old Password is not correct
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+        '401':
+          description: If the userId from the Authentification Header and the request-parameter id don't match
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+  '/members/{id}/changePasswordAdmin':
+    put:
+      summary: Change the password of a specific member as admin
+      operationId: updatePasswordAsAdmin
+      tags:
+        - Members
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: The id of the Member, 
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        description: the new password
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                newPassword:
+                  $ref: '#/components/schemas/Password'
+      responses:
+        '204':
+          description: Expected response to a valid request
+        '401':
+          description: When the user is not admin
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+        '404':
+          description: When there is no User with the specified Id
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
 components:
   schemas:
-    NewMember:
+    PutMember:
       required:
         - firstName
         - lastName
@@ -240,8 +330,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Authorization'
-        password:
-          type: string
+    PostMember:
+      allOf:
+        - required:
+          - password
+          properties:
+            password:
+              $ref: '#/components/schemas/Password'
+        - $ref: '#/components/schemas/PutMember'       
     Member:
       description: services ist noch vorläufig
       allOf:
@@ -260,7 +356,7 @@ components:
               type: array
               items:
                 $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Service'
-        - $ref: '#/components/schemas/NewMember'
+        - $ref: '#/components/schemas/PutMember'
     ListMember:
       required:
         - id
@@ -307,3 +403,6 @@ components:
         title:
           type: string
           enum: [VORSTANDSVORSITZENDER, SYSTEMADMINISTRATOR, KASSIERER, FLUGWART, IMBETRIEBSKONTROLLTURMARBEITEND]
+    Password:
+      type: string
+      description: "Mind: 8 Zeichen, 1 Zahl, 1 Buchstabe"

--- a/members.yaml
+++ b/members.yaml
@@ -197,7 +197,7 @@ paths:
                 $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
   '/members/{id}/changePasswordAsMember':
     put:
-      summary: Change the password of a specific member
+      summary: Change your own password as a normal user.
       operationId: updatePasswordAsUser
       tags:
         - Members
@@ -243,7 +243,7 @@ paths:
                 $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
   '/members/{id}/changePasswordAsAdmin':
     put:
-      summary: Change the password of a specific member as admin
+      summary: Change the password for another user as admin
       operationId: updatePasswordAsAdmin
       tags:
         - Members

--- a/members.yaml
+++ b/members.yaml
@@ -405,4 +405,5 @@ components:
           enum: [VORSTANDSVORSITZENDER, SYSTEMADMINISTRATOR, KASSIERER, FLUGWART, IMBETRIEBSKONTROLLTURMARBEITEND]
     Password:
       type: string
+      format: password
       description: "Mind: 8 Zeichen, 1 Zahl, 1 Buchstabe"

--- a/members.yaml
+++ b/members.yaml
@@ -241,7 +241,7 @@ components:
           items:
             $ref: '#/components/schemas/Authorization'
         password:
-        type: string
+          type: string
     Member:
       description: services ist noch vorläufig
       allOf:

--- a/members.yaml
+++ b/members.yaml
@@ -195,7 +195,7 @@ paths:
             application/json:
               schema:
                 $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-  '/members/{id}/changePassword':
+  '/members/{id}/changePasswordAsMember':
     put:
       summary: Change the password of a specific member
       operationId: updatePasswordAsUser

--- a/members.yaml
+++ b/members.yaml
@@ -241,7 +241,7 @@ paths:
             application/json:
               schema:
                 $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/openapi.yaml#/components/schemas/Error'
-  '/members/{id}/changePasswordAdmin':
+  '/members/{id}/changePasswordAsAdmin':
     put:
       summary: Change the password of a specific member as admin
       operationId: updatePasswordAsAdmin

--- a/members.yaml
+++ b/members.yaml
@@ -208,6 +208,7 @@ components:
         - address
         - bankingAccount
         - admissioned
+        - password
       properties:
         firstName:
           type: string
@@ -239,6 +240,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Authorization'
+        password:
+        type: string
     Member:
       description: services ist noch vorläufig
       allOf:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,7 +15,7 @@ paths:
       tags: 
       - Login
       responses:
-        '200':
+        '204':
           description: When userID and password are correct
         '401':
           description: When userID and password are not correct
@@ -195,7 +195,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 components:
- securitySchemes:
+  securitySchemes:
     basicAuth:
       type: http
       scheme: basic

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 0.3.4
+  version: 0.4.4
   title: WWI16AMA - Spec
   license:
     name: APL 2

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,6 +7,18 @@ info:
 servers:
   - url: 'http://wwi16ama.feste-ip.net/backend_api/'
 paths:
+  /loginCheck:
+    get:
+      summary: Checks if given userID and password are correct
+      security:
+        - basicAuth: []
+      tags: 
+      - Login
+      responses:
+        '200':
+          description: When userID and password are correct
+        '401':
+          description: When userID and password are not correct
   /members:
     $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/paths/~1members'
   '/members/{id}':
@@ -183,6 +195,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 components:
+ securitySchemes:
+    basicAuth:
+      type: http
+      scheme: basic
   schemas:
     Member:
       $ref: 'https://raw.githubusercontent.com/wwi16ama/api_spec/master/members.yaml#/components/schemas/Member'


### PR DESCRIPTION
Added securitySchemes (basicAuth) to show that this route is secured via basic auth -> Authorization header needed.
- Adding security to get route 'loginCheck' shows a lock icon in swagger ui to show that basic auth is needed in header.

We need to update this on all other routes which require basicAuth
(To be honest I hope this is the right way to add basicAuth to a route in swagger)


Also added the required password parameter in Member post route body