### PR TITLE
Lass mal 204 statt 200 nehmen

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,7 +15,7 @@ paths:
       tags: 
       - Login
       responses:
-        '200':
+        '204':
           description: When userID and password are correct
         '401':
           description: When userID and password are not correct
@@ -195,7 +195,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 components:
- securitySchemes:
+  securitySchemes:
     basicAuth:
       type: http
       scheme: basic


### PR DESCRIPTION
> Aside from responses to CONNECT, a 200 response always has a payload, though an origin server MAY generate a payload body of zero length. If no payload is desired, an origin server ought to send `204 No Content` instead. For CONNECT, no payload is allowed because the successful result is a tunnel, which begins immediately after the 200 response header section.

https://httpstatuses.com/200