### PR TITLE
Add memberID to loginCheck route response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,8 +15,17 @@ paths:
       tags: 
       - Login
       responses:
-        '204':
+        '200':
           description: When userID and password are correct
+          content:
+            application/json:
+              schema:
+                required:
+                - memberID
+                type: object
+                properties:
+                  memberID:
+                    type: integer
         '401':
           description: When userID and password are not correct
   /members:


### PR DESCRIPTION
Mir ist eingefallen dass wir um zu wissen welches Mitglied eingeloggt ist bei der loginCheck route als response die memberID  bekommen müssen.