### PR TITLE
Add fligthId in pilotlogentry post response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -303,7 +303,8 @@ components:
     NewPilotLogEntry:
       properties:
         flightId:
-          type: int32
+          type: integer
+          format: int32
         planeNumber:
           type: string
         departureLocation: 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -302,6 +302,8 @@ components:
           type: boolean
     NewPilotLogEntry:
       properties:
+        flightId:
+          type: int32
         planeNumber:
           type: string
         departureLocation: 


### PR DESCRIPTION
The pilotlogentry object which is send in the post response body needs to contain the flightId. As far as I know this is already implemented in frontend as well as in work in backend we just need do adjust the api spec to fit