### PR TITLE
add restriction to pictureUrl

### DIFF
--- a/planes.yaml
+++ b/planes.yaml
@@ -216,6 +216,7 @@ components:
           type: string
         pictureUrl:
           type: string
+          maxLength: 255
           format: uri
         neededAuthorization:
           type: string


### PR DESCRIPTION
Da die pictureUrl als VARCHAR(255) gespeichert wird, darf die Länge 255 Zeichen nicht überschreiten. Wird eine pictureUrl die länger als 255 Zeichen ist angegeben crasht das backend
![Screenshot_20190402_113119](https://user-images.githubusercontent.com/23587188/55392081-d914e480-553a-11e9-8965-c7eb64ce7643.png)

Um zu vermeiden, dass das backend in diesem fall flöten geht sollte die länge der pictureUrl vor dem speichern überprüft werden. Das Frontend wird bei der eingabe überprüfen, ob die pictureUrl weniger zeichen als 255 beinhaltet sodass durch das frontend dies nicht passieren sollte, jedoch kann dieser fall trotzdem z.b. mit postman provoziert werden