### PR TITLE
Transaction ohne Enum, `type` -> `text`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -494,14 +494,13 @@ components:
     NewTransaction:
       required:
         - amount
-        - type
+        - text
       properties:
         amount:
           type: number
           format: double
-        type:
+        text:
           type: string
-          enum: ["MITGLIEDSBEITRAG", "GEBÜHRFLUGZEUG", "GUTSCHRIFTAMT", "GUTSCHRIFTLEISTUNG","EINZAHLUNG", "AUSZAHLUNG"]
     Transaction:
       allOf:
         - properties:


### PR DESCRIPTION
Ich schlage vor, das Feld umzubenennen, da es inzwischen nicht mehr um den Typus geht sondern eher ein _Freitext_ ist.
Alternativvorschläge für den Namen?

@simon10419 du hattest damals die ENUM-Werte erweitert (PR #9). Wie kam's dazu / geht was kaputt, wenn's kein ENUM mehr is?