### PR TITLE
Aufwandsverrechnung fluege

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -324,7 +324,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NewPilotLogEntry'
+                $ref: '#/components/schemas/PilotLogEntry'
+        '400':
+          description: Response when request is wrong, i.e. if required fields are empty
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Response when no PioltLog of specific Member is found
           content:
@@ -430,6 +436,10 @@ components:
               type: integer
               format: int32
         - $ref: '#/components/schemas/NewPilotLogEntry'
+        - properties:
+            flightPrice:
+              type: number
+              format: double
     NewPilotLogEntry:
       properties:
         planeNumber:
@@ -446,6 +456,9 @@ components:
           format: date-time
         flightWithGuests:
           type: boolean
+        usageTime:
+          type: integer
+          format: int32
     PlaneLogEntry:
       allOf:
         - properties:
@@ -470,7 +483,7 @@ components:
         endCount:
           type: number
           format: float
-        totalPrice:
+        fuelPrice:
           type: number
           format: float
     Member:

--- a/planes.yaml
+++ b/planes.yaml
@@ -210,6 +210,7 @@ components:
       properties:
         number:
           type: string
+          description: The PlaneNumber must be unique. I.e there's only one plane with the number D-ERFI
         name:
           type: string
         position:


### PR DESCRIPTION
Soo hier die PR für die Anpassung an Pilotlog wg. der Aufwandsverrechnung der Flüge.
Wichtig ist hier für das Frontend, dass sich einerseits das Pilotlog ändert  (glaube da war @simon10419 im Thema) und das Planelog (das hatte glaube ich @Yann1c gemacht). Pilotlog wird um die Attribute usageTime und flightPrice erweitert, im Planelog wurde der totalPrice zu fuelPrice umbenannt. Schaut euch das bitte mal an wie es nun umgesetzt ist. Bei Fragen und Anmerkungen melden.